### PR TITLE
Prevent DOM scrolling on kill shortcut

### DIFF
--- a/src/nextjournal/clojure_mode/commands.cljs
+++ b/src/nextjournal/clojure_mode/commands.cljs
@@ -32,7 +32,7 @@
     (.setAttribute input-el "class" "clipboard-input")
     (j/assoc! input-el :innerHTML text)
     (-> js/document .-body (.appendChild input-el))
-    (.focus input-el)
+    (.focus input-el {:preventScroll true})
     (.select input-el)
     (js/document.execCommand "copy")
     (.focus focus-el #js {:preventScroll true})


### PR DESCRIPTION
I noticed when using clojure-mode on a tall page, whenever I tried the kill command (Ctrl-k) the kill would happen correctly but my page would get scrolled down to the bottom. This was because my browser was focusing on the temporary textarea element created in the copy-to-clipboard! function. Adding `:preventScroll true` fixed the problem for me.