### PR TITLE
Adam frey/scroll on kill

### DIFF
--- a/src/nextjournal/clojure_mode/commands.cljs
+++ b/src/nextjournal/clojure_mode/commands.cljs
@@ -31,7 +31,7 @@
     (.setAttribute input-el "class" "clipboard-input")
     (j/assoc! input-el :innerHTML text)
     (-> js/document .-body (.appendChild input-el))
-    (.focus input-el)
+    (.focus input-el {:preventScroll true})
     (.select input-el)
     (js/document.execCommand "copy")
     (.focus focus-el #js {:preventScroll true})

--- a/src/nextjournal/clojure_mode/commands.cljs
+++ b/src/nextjournal/clojure_mode/commands.cljs
@@ -31,7 +31,7 @@
     (.setAttribute input-el "class" "clipboard-input")
     (j/assoc! input-el :innerHTML text)
     (-> js/document .-body (.appendChild input-el))
-    (.focus input-el {:preventScroll true})
+    (.focus input-el #js {:preventScroll true})
     (.select input-el)
     (js/document.execCommand "copy")
     (.focus focus-el #js {:preventScroll true})


### PR DESCRIPTION
Cherry picked from / closes #23.

> I noticed when implementing clojure-mode on a tall page, whenever I
tried the kill command (Ctrl-k) the kill would happen correctly but my
page would get scrolled down to the bottom. This was because my browser
was focusing on the temporary textarea element created in the
copy-to-clipboard! function. Adding :preventScroll true fixed the
problem for me.

Couldn't reproduce on Chrome but I find the change makes sense. I also think the original change could not have any effect.