### PR TITLE
Improve Edit Performance

### DIFF
--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -289,6 +289,7 @@ $$\\hat{f}(x) = \\int_{-\\infty}^{+\\infty} f(t)\\exp^{-2\\pi i x t}dt$$
 - [x] fix loosing cursor moving up/down to enter a preview block
 - [ ] fix blocks when editing last one in edit-all mode
 - [ ] fix overflow-x in blocks
+- [ ] fix selecting positions with click in editable sections between previews
 - [ ] fix Clerk plotly/vega viewers
 - [x] eval region in clojure blocks
 - [x] toggle previews editable on cursor enter/leave

--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -287,7 +287,7 @@ $$\\hat{f}(x) = \\int_{-\\infty}^{+\\infty} f(t)\\exp^{-2\\pi i x t}dt$$
 - [x] make previews selectable with arrow keys
 - [x] make previews editable on click
 - [x] fix loosing cursor moving up/down to enter a preview block
-- [ ] fix blocks when editing last one in edit-all mode
+- [x] fix blocks when editing last one in edit-all mode
 - [ ] fix overflow-x in blocks
 - [ ] fix selecting positions with click in editable sections between previews
 - [ ] fix Clerk plotly/vega viewers
@@ -297,9 +297,9 @@ $$\\hat{f}(x) = \\int_{-\\infty}^{+\\infty} f(t)\\exp^{-2\\pi i x t}dt$$
 - [ ] fix (?) dispatching changes/annotations twice
 - [x] bring Clerk stylesheet in demo
 - [x] toggle edit all by a second hit of ESC
-- [ ] make livedoc extensions configurable
-- [ ] fix moving to the right in backticks
-- [ ] autoclose backticks
+- [x] make livedoc extensions configurable
+- [x] fix moving to the right in backticks
+- [x] autoclose backticks
 - [x] fix eval for empty code cells
 "}]]] (js/document.getElementById "markdown-preview"))
 

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -6,7 +6,7 @@
   * per-block edit mode"
   (:require ["@codemirror/language" :refer [syntaxHighlighting defaultHighlightStyle syntaxTree Language LanguageSupport indentNodeProp]]
             ["@codemirror/lang-markdown" :as MD :refer [markdown markdownLanguage]]
-            ["@codemirror/state" :refer [EditorState StateField StateEffect Prec Range]]
+            ["@codemirror/state" :refer [EditorState StateField StateEffect Prec]]
             ["@codemirror/view" :as view :refer [EditorView Decoration WidgetType keymap showTooltip]]
             ["@lezer/markdown" :as lezer-markdown]
             [applied-science.js-interop :as j]

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -297,8 +297,7 @@
 
           (or doc-changed? edit-all?)
           (do
-            (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op preview-all-and-select})
-                                       #_#_ :selection {:anchor (->cursor-pos (.-state view))}})))
+            (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op preview-all-and-select})})))
             true)
 
           'edit-one
@@ -307,8 +306,8 @@
 
         ;; move up/down selection
         selected #_ (not= :esc key)
-        (let [at (case key :up (bounded-dec selected) :down (bounded-inc selected (count block-seq)))]
-          (.. view (dispatch (j/lit {:selection {:anchor (inc (:from (nth block-seq at)))}
+        (let [next-idx (case key :up (bounded-dec selected) :down (bounded-inc selected (count block-seq)))]
+          (.. view (dispatch (j/lit {:selection {:anchor (:from (nth block-seq next-idx))}
                                      :effects (.of doc-apply-op {:op preview-all-and-select})})))
           true)
 

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -327,20 +327,18 @@
         (= :esc key)
         (cond
           selected
-          (let [at (inc (:from (nth blocks selected)))]
+          (let [at (inc (:from (nth block-seq selected)))]
             (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op edit-at :args [at]})
                                        :selection {:anchor at}})))
             true)
 
-          ;; FIXME
-          true #_ (or doc-changed? edit-all?)
+          (or doc-changed? edit-all?)
           (do
             (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op preview-all-and-select})
                                        #_#_ :selection {:anchor (->cursor-pos (.-state view))}})))
             true)
 
-          ;; FIXME
-          false #_ 'edit-one
+          'edit-one
           (do (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op edit-all})})))
               true))
 

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -295,7 +295,7 @@
                      (:down :right) (bounded-inc index (count blocks)))]
     (when (not= next-index index)
       (let [line (.. view -state -doc (lineAt pos))
-            next-block (get blocks next-index)]
+            next-block (nth blocks next-index)]
         ;; blocks span entire lines we can argue by an offset of at most the current line + 1
         (case key
           (:down :right)
@@ -351,12 +351,9 @@
 
         ;; check we're entering a preview from an edit region
         ;; (not selected) implies we're in edit. Also check we're not expanding/shrinking a paredit region
-        ;; FIXME
-        false
-        #_
         (and (not selected) (not edit-all?) (not (.. view -state (field eval-region-tooltip)))
              (or (= :up key) (= :down key) (= :left key) (= :right key)))
-        (when-some [at (edit-adjacent-block-at view blocks key)]
+        (when-some [at (edit-adjacent-block-at view block-seq key)]
           (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op edit-at :args [at]})
                                      :selection {:anchor at}})))
           true)

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -343,14 +343,11 @@
               true))
 
         ;; move up/down selection
-        ;; FIXME
-        false
-        #_
         (and selected (or (= :up key) (= :down key)))
-        (let [at (case key :up (bounded-dec selected) :down (bounded-inc selected (count blocks)))]
-          (.. view (dispatch (j/lit {:selection {:anchor (inc (:from (get blocks at)))}
-                                     :effects (.of doc-apply-op {:op preview-all-and-select :args [at]})})))
-          false)
+        (let [at (case key :up (bounded-dec selected) :down (bounded-inc selected (count block-seq)))]
+          (.. view (dispatch (j/lit {:selection {:anchor (inc (:from (nth block-seq at)))}
+                                     :effects (.of doc-apply-op {:op preview-all-and-select})})))
+          true)
 
         ;; check we're entering a preview from an edit region
         ;; (not selected) implies we're in edit. Also check we're not expanding/shrinking a paredit region

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -273,12 +273,10 @@
 ;; Keyborad event handling
 (defn edit-adjacent-block-at [^js view blocks key]
   (let [pos (->cursor-pos (.-state view))]
-    (when-some [next-block (when-not (pos->block-idx blocks pos)
-                             ;; ⬆ we're not inside any preview block
-                             ;; ⬇ get the first adjacent block met wrt the current movement direction
-                             (case key
-                               (:up :left) (some (when-fn #(<= (:to %) pos)) (reverse blocks))
-                               (:down :right) (some (when-fn #(< pos (:from %))) blocks)))]
+    ;; get the first adjacent block we meet wrt the current movement direction
+    (when-some [next-block (case key
+                             (:up :left) (some (when-fn #(<= (:to %) pos)) (reverse blocks))
+                             (:down :right) (some (when-fn #(<= pos (:from %))) blocks))]
       (let [line (.. view -state -doc (lineAt pos))]
         ;; blocks span entire lines we can argue by an offset of at most the current line + 1
         (case key
@@ -286,7 +284,7 @@
           (let [offset (when (= :down key) (- (.-to line) pos))
                 new-pos (cond-> (inc pos) offset (+ offset))
                 end (.. view -state -doc -length)]
-            (when (or (<= (:from next-block) new-pos)
+            (when (or (< (:from next-block) new-pos)
                       (and (= :down key)
                            ;; we'd reach end of doc by jumping across decorations
                            (= end (.. view (moveVertically (.. view -state -selection -main) true) -anchor))))

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -180,12 +180,7 @@
                          :ignoreEvent (constantly false)
                          :toDOM (partial render-block-preview this)
                          :spec (dissoc opts :selected?)
-                         ;; TODO: try to use text equality
-                         #_#_
-                         :eq (fn [^js other]
-                               (and (identical? (.-from this) (.-from other))
-                                    (identical? (.-to this) (.-to other))
-                                    (identical? (.-isSelected this) (.-isSelected other))))))) ;; redraw on selection change
+                         :eq (fn [^js other] (identical? (.-id this) (.-id other))))))
 
 ;; Document State Field
 (defn block-opts->widget
@@ -194,25 +189,12 @@
       (replace (j/obj :block true :widget (BlockPreviewWidget. opts)))
       (range from to)))
 
-(defn into-array* [xf coll] (reduce (xf j/push!) (array) coll))
-#_(into-array* (comp (map inc) (remove odd?)) [1 2 3])
-
-#_
-(defn doc->preview-decorations [{:keys [selected blocks edit-all?]}]
-  (if edit-all?
-    (.-none Decoration)
-    (.set Decoration
-          (into-array* (comp (remove :edit?) (map block-opts->widget))
-                       (cond-> blocks
-                         selected (assoc-in [selected :selected?] true))))))
-
 (defonce ^{:doc "Maintains a document description at block level"}
   doc-state
   (.define StateField
            (j/obj
             :provide (fn [field] (.. EditorView -decorations (from field #(get % :blocks))))
             :create (fn [cm-state]
-
                       {:selected nil
                        :blocks (.set Decoration (state->blocks cm-state {:select? false}))})
             :update (fn [{:as doc :keys [edit-all?]} ^js tr]


### PR DESCRIPTION
Use Codemirror RangeSet collection type to model document blocks. In this way we can efficiently map decorations while editing a cell instead of rebuilding them at every key-stroke.