### PR TITLE
Separate evaluation from render

### DIFF
--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -251,6 +251,7 @@ have an editor with ~~mono~~ _mixed language support_.
                                                               (rdom/render [:div.p-3 [eval-code-view text]] tt-el)
                                                               (j/obj :dom tt-el)))
 
+                                                 ;; each cell is assigned a `state` reagent atom
                                                  :eval-fn!
                                                  (fn [state]
                                                    (when state
@@ -260,7 +261,7 @@ have an editor with ~~mono~~ _mixed language support_.
                                                  :render
                                                  (fn [state]
                                                    (fn []
-                                                     (let [{:as s :keys [text type selected?] r :result} @state]
+                                                     (let [{:keys [text type selected?] r :result} @state]
                                                        #_(when (not-empty (str/trim text)))
                                                        ;; skip empty markdown blocks
                                                        [:div.flex.flex-col.rounded.border.m-2
@@ -355,10 +356,16 @@ $$\\hat{f}(x) = \\int_{-\\infty}^{+\\infty} f(t)\\exp^{-2\\pi i x t}dt$$
                                                (rdom/render [:div.p-3 [eval-code-view text]] tt-el)
                                                (j/obj :dom tt-el)))
 
+                                  :eval-fn!
+                                  (fn [state]
+                                    (when state
+                                      (swap! state (fn [{:as s :keys [text]}]
+                                                     (assoc s :result (demo.sci/eval-string text))))))
+
                                   :render
                                   (fn [state]
                                     (fn []
-                                      (let [{:as s :keys [text type selected?] r :result} @state]
+                                      (let [{:keys [text type selected?] r :result} @state]
                                         [:div.flex.flex-col.rounded.border.m-2
                                          {:class [(when selected? "ring-4") (when (= :code type) "bg-slate-100")]}
                                          (case type

--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -253,17 +253,15 @@ have an editor with ~~mono~~ _mixed language support_.
 
                                                  :eval-fn!
                                                  (fn [state]
-                                                   (js/console.log :eval-fn! state)
                                                    (when state
-                                                     (swap! state (fn [s]
-                                                                    (let [{:keys [text]} @s]
-                                                                      (assoc s :result (demo.sci/eval-string text)))))))
+                                                     (swap! state (fn [{:as s :keys [text]}]
+                                                                    (assoc s :result (demo.sci/eval-string text))))))
 
                                                  :render
                                                  (fn [state]
                                                    (fn []
                                                      (let [{:as s :keys [text type selected?] r :result} @state]
-                                                       #_ (when (not-empty (str/trim text)))
+                                                       #_(when (not-empty (str/trim text)))
                                                        ;; skip empty markdown blocks
                                                        [:div.flex.flex-col.rounded.border.m-2
                                                         {:class [(when selected? "ring-4") (when (= :code type) "bg-slate-100")]}
@@ -361,7 +359,6 @@ $$\\hat{f}(x) = \\int_{-\\infty}^{+\\infty} f(t)\\exp^{-2\\pi i x t}dt$$
                                   (fn [state]
                                     (fn []
                                       (let [{:as s :keys [text type selected?] r :result} @state]
-                                        (js/console.log :selected? selected?)
                                         [:div.flex.flex-col.rounded.border.m-2
                                          {:class [(when selected? "ring-4") (when (= :code type) "bg-slate-100")]}
                                          (case type

--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -232,6 +232,10 @@ have an editor with ~~mono~~ _mixed language support_.
                 [:div.mb-5.bg-white.max-w-4xl.mx-auto.border
                  [key-bindings-table {:toggle-preview
                                       [{:key "Esc" :doc "Toggles Edit-Cell / Edit-all / Preview-and-select modes"}]
+                                      :eval
+                                      [{:key "Meta-Enter" :doc "Evaluate selected cell / preview when editing a cell"}]
+                                      :eval-all
+                                      [{:key "Shift-Meta-Enter" :doc "Evaluate all cells"}]
                                       :select-previous-block
                                       [{:key "ArrowUp" :doc "Selects block before the current selection"}]
                                       :select-next-block

--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -86,19 +86,19 @@
                 (when el
                   (some-> el .-editorView .destroy)
                   (j/assoc! el :editorView
-                            (doto (EditorView. (j/obj :parent el
-                                                      :state (.create EditorState
-                                                                      (j/obj :doc (str/trim doc)
-                                                                             :extensions (into-array
-                                                                                          (cond-> [(syntaxHighlighting defaultHighlightStyle)
-                                                                                                   (foldGutter)
-                                                                                                   (.of view/keymap cm-clj/complete-keymap)
-                                                                                                   (history)
-                                                                                                   (.of view/keymap historyKeymap)
-                                                                                                   theme
-                                                                                                   livedoc/markdown-language-support]
-                                                                                            (seq extensions)
-                                                                                            (concat extensions))))))) .focus))))}])
+                            (EditorView. (j/obj :parent el
+                                                :state (.create EditorState
+                                                                (j/obj :doc (str/trim doc)
+                                                                       :extensions (into-array
+                                                                                    (cond-> [(syntaxHighlighting defaultHighlightStyle)
+                                                                                             (foldGutter)
+                                                                                             (.of view/keymap cm-clj/complete-keymap)
+                                                                                             (history)
+                                                                                             (.of view/keymap historyKeymap)
+                                                                                             theme
+                                                                                             livedoc/markdown-language-support]
+                                                                                      (seq extensions)
+                                                                                      (concat extensions))))))))))}])
 
 (defn samples []
   (into [:<>]

--- a/demo/src/nextjournal/clojure_mode/demo.cljs
+++ b/demo/src/nextjournal/clojure_mode/demo.cljs
@@ -276,8 +276,9 @@ have an editor with ~~mono~~ _mixed language support_.
                                                            [sv/inspect-paginated (v/with-viewer :markdown (:text @state))]]
 
                                                           :code
-                                                          [:div.max-w-prose.p-2
-                                                           [sv/inspect-paginated (v/with-viewer :code text)]
+                                                          [:div.p-2
+                                                           [:div.max-w-prose
+                                                            [sv/inspect-paginated (v/with-viewer :code text)]]
                                                            [:hr.border]
                                                            [:div.viewer-result {:style {:font-family "var(--code-font)"}}
                                                             (when-some [{:keys [error result]} r]

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -509,7 +509,7 @@
                                                         :state (.create EditorState
                                                                         (j/obj :doc (str/trim doc)
                                                                                :extensions (into-array
-                                                                                            (-> (extensions (select-keys opts [:render :tooltip]))
+                                                                                            (-> (extensions (select-keys opts [:render :tooltip :eval-fn!]))
                                                                                                 (concat [(syntaxHighlighting defaultHighlightStyle)
                                                                                                          (.of keymap cm-clj/complete-keymap)
                                                                                                          markdown-language-support])

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -197,7 +197,6 @@
             :update (fn [{:as doc :keys [edit-all?]} ^js tr]
                       (let [{:as apply-op :keys [op args]} (get-effect-value tr doc-apply-op)
                             {:as me :strs [Meta Shift]} (get-effect-value tr eval-region/modifier-effect)]
-                        (js/console.log :ME (str me))
                         (cond
                           apply-op (apply op doc tr args)
                           (.-docChanged tr)

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -452,8 +452,13 @@
 
 (defn extensions
   "Accepts an `opts` map with optional keys:
-   * `:render` A map with keys `:markdown` and `:code` providing render functions (String -> HTMLElement)
-      for each block type.
+   * `:render` a component function taking a reagent atom as argument, such \"state\" derefs to a map with keys:
+      - `:text` a cell's text
+      - `:type` with values `:code` or `:markdown`
+      - `:selected?`
+      the component is used to render blocks in preview mode
+
+   * `:eval-fn!` a function which is called against each selected block's state when eval commands are invoked
 
    * `:tooltip` (String -> EditorView -> TooltipView) as per https://codemirror.net/docs/ref/#view.TooltipView
       when present, enables a Codemirror tooltips.
@@ -495,11 +500,16 @@
 
 ;; Editor
 (defn editor
-  "A convenience function/component bundling a basic setup with
+  "A convenience function/component bundling a basic editor setup with
 
-  * markdown + clojure-mode language support and their syntax highlighting
-  * clojure mode keybindings
-  * livedoc extensions configurable via `opts`"
+  * markdown + nested clojure-mode language support and their syntax highlighting
+  * clojure mode keybindings for paredit actions among others
+  * livedoc extensions configurable via `opts` (see `extensions`).
+
+  Takes extra keys:
+   - `:doc` a markdown string setting the editor's initial document
+   - `:extenstions` extra codemirror extensions to be stacked on top of the default
+   - `:focus?` when true let the codemirror instance acquire focus."
   [{:as opts extras :extensions :keys [doc focus?]}]
   [:div {:ref (fn [^js el]
                 (when el

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -259,7 +259,7 @@
                                      (and (<= from (n/start node)) (<= (n/end node) to))
                                      (j/push! (node-info->decoration state
                                                                      {:from (n/start node)
-                                                                      :to (inc (n/end node))
+                                                                      :to (min (inc (n/end node)) to)
                                                                       ;; ⬆ note this assumes no trailing whitespace after closing ```
                                                                       :node (.-node node)
                                                                       :type :code

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -122,7 +122,7 @@
                              (and selected-block (not (block-eq? selected-block current-block)))
                              (j/assoc! :add (array (update-block selected-block #(assoc % :selected? false)))))))))))
 
-(defn preview-and-select [doc tr]
+(defn preview+select+eval [doc tr]
   (let [gap-blocks (edit-gap-blocks doc (.-state tr))]
     (cond-> doc
       gap-blocks
@@ -178,7 +178,7 @@
 (defn preview+eval [{:as doc :keys [selected edit-from edit-all? blocks]} tr all?]
   (cond
     edit-all? (preview-all+select+eval doc tr)
-    edit-from (preview-and-select doc tr)
+    edit-from (preview+select+eval doc tr)
     'else (do
             (cond
               all?
@@ -416,7 +416,7 @@
 
           (and edit-from doc-changed?)
           (do
-            (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op preview-and-select})})))
+            (.. view (dispatch (j/lit {:effects (.of doc-apply-op {:op preview+select+eval})})))
             true)
 
           'edit-one

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -92,13 +92,14 @@
 
 (defn edit-at [{:as doc :keys [selected blocks edit-from]} ^js tr pos]
   ;; we patch the existing decoration with blocks arising from last editable region
-  (let [current-block (block-at blocks pos)
+  (let [{:as current-block :keys [from]} (block-at blocks pos)
         ^js gap-blocks (edit-gap-blocks doc (.-state tr))
         ^js selected-block (when selected (nth (rangeset-seq blocks) selected))]
     (cond-> doc
       current-block
       (-> (dissoc :selected :edit-all?)
-          (assoc :edit-from (:from current-block))
+          (assoc :edit-from from
+                 :doc-changed? (and edit-from (not= edit-from from)))
           (update :blocks
                   (fn [bs]
                     (.update ^js bs

--- a/src/nextjournal/livedoc.cljs
+++ b/src/nextjournal/livedoc.cljs
@@ -60,10 +60,12 @@
 ;; Config
 (def default-config
   {:render (fn [state]
-             (let [{:keys [type text]} @state]
-               (case type
-                 :markdown [:pre.md text]
-                 :code [:pre.code text])))})
+             (let [{:keys [type text selected?]} @state]
+               [:div.m-2.border.rounded
+                {:class [(when selected? "ring-4") (when (= :code type) "bg-slate-100")]}
+                (case type
+                  :markdown [:div.p-2 text]
+                  :code [:code [:pre.p-2 text]])]))})
 
 (defonce ^{:doc "Configurable entrypoint see also `extensions/1` fn below."}
   config-state
@@ -433,7 +435,7 @@
    "
   ([] (extensions {}))
   ([opts]
-   (cons (cond-> config-state (seq opts) (.init (constantly opts)))
+   (cons (cond-> config-state (seq opts) (.init #(merge default-config opts)))
          default-extensions)))
 
 ;; Markdown Language Support


### PR DESCRIPTION
* Use a reagent atom to update cell's view as much as possible without rebuilding their DOM element on every actions.
* Implement eval based on explicit use interaction